### PR TITLE
Use fully-qualified collection names

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Load var file with package names based on the OS type
-  include_vars: "{{ lookup('first_found', params) }}"
+  ansible.builtin.include_vars: "{{ lookup('first_found', params) }}"
   vars:
     params:
       files:
@@ -11,26 +11,26 @@
         - "{{ role_path }}/vars"
 
 - name: Install chrony
-  package:
+  ansible.builtin.package:
     name:
       - chrony
 
 - name: Enable chrony at boot
-  service:
+  ansible.builtin.service:
     name: "{{ service_name }}"
     enabled: yes
 
 - name: Configure chrony to use Amazon Time Sync Service
   block:
     - name: Comment out existing pool lines
-      replace:
+      ansible.builtin.replace:
         path: "{{ config_file }}"
         regexp: ^(pool .*)
         replace: '# \1'
     - name: >
         Comment out existing server lines that do not correspond to the
         Amazon Time Sync Service
-      replace:
+      ansible.builtin.replace:
         path: "{{ config_file }}"
         # The negative lookahead makes this regex match lines that
         # start with "server " but _do not_ look like "server
@@ -39,7 +39,7 @@
         regexp: ^(server (?!169\.254\.169\.123 prefer iburst).*)
         replace: '# \1'
     - name: Add a server line for Amazon Time Sync Service
-      blockinfile:
+      ansible.builtin.blockinfile:
         block: |
           # Sync with Amazon Time Sync Service
           server 169.254.169.123 prefer iburst

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,8 +17,8 @@
 
 - name: Enable chrony at boot
   ansible.builtin.service:
-    name: "{{ service_name }}"
     enabled: yes
+    name: "{{ service_name }}"
 
 - name: Configure chrony to use Amazon Time Sync Service
   block:


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request updates this role to use fully-qualified collection names for Ansible tasks and to ensure that all task arguments are sorted alphabetically.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

I am hunting down a deprecation warning while building fresh [CyHy AMIs](https://github.com/cisagov/cyhy_amis) and this is the first Ansible dependency I checked. While the warning was not found here I saw a couple out-of-date items and thought I would correct them while I'm here.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass successfully.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
